### PR TITLE
阻止玩家的一些离谱操作

### DIFF
--- a/src/main/java/cn/goldenpotato/oxygensystem/Config/Config.java
+++ b/src/main/java/cn/goldenpotato/oxygensystem/Config/Config.java
@@ -26,4 +26,6 @@ public class Config
     public static boolean PlayItemUpgradeSound;
     public static boolean PlayOxygenTankUseSound;
     public static boolean PlayRefillOxygenSound;
+    public static double OxygenReducedOnDamagedOthers;
+    public static double OxygenReducedOnRunning;
 }

--- a/src/main/java/cn/goldenpotato/oxygensystem/Config/ConfigManager.java
+++ b/src/main/java/cn/goldenpotato/oxygensystem/Config/ConfigManager.java
@@ -29,6 +29,8 @@ public class ConfigManager
         Config.OxygenTank = reader.getInt("OxygenTank",300);
         Config.RoomOxygenAdd = reader.getInt("RoomOxygenAdd",5);
         Config.OxygenStationOxygenAdd = reader.getInt("OxygenStationOxygenAdd",300);
+        Config.OxygenReducedOnDamagedOthers = reader.getDouble("OxygenReducedOnDamagedOthers", 0.5);
+        Config.OxygenReducedOnRunning = reader.getDouble("OxygenReducedOnRunning",0.2);
 
         //Sound
         Config.PlayMachineStartUpSound = reader.getBoolean("PlayMachineStartUpSound",true);

--- a/src/main/java/cn/goldenpotato/oxygensystem/Config/Message.java
+++ b/src/main/java/cn/goldenpotato/oxygensystem/Config/Message.java
@@ -54,4 +54,6 @@ public class Message
     public String SubCommand_Remove_Usage;
     public String SubCommand_Help_Usage;
     public String SubCommand_Help_NoSuchCommand;
+    public String CantPlace;
+    public String CantCraft;
 }

--- a/src/main/java/cn/goldenpotato/oxygensystem/Config/MessageManager.java
+++ b/src/main/java/cn/goldenpotato/oxygensystem/Config/MessageManager.java
@@ -35,6 +35,8 @@ public class MessageManager
         msg.AlreadySealed = messageReader.getString("AlreadySealed","");
         msg.NotEnabled = messageReader.getString("NotEnabled","");
         msg.OxygenStation_NotInRoom = messageReader.getString("OxygenStation_NotInRoom","");
+        msg.CantPlace = messageReader.getString("CantPlace", "");
+        msg.CantCraft = messageReader.getString("CantCraft", "");
 
         msg.MaskUpgrade_WrongTier = messageReader.getString("MaskUpgrade_WrongTier","");
         msg.Item_MaskUpgradeT1 = messageReader.getString("Item_MaskUpgradeT1","");

--- a/src/main/java/cn/goldenpotato/oxygensystem/Listener/PlayerInteractListener.java
+++ b/src/main/java/cn/goldenpotato/oxygensystem/Listener/PlayerInteractListener.java
@@ -13,10 +13,14 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
+import org.bukkit.event.block.BlockPlaceEvent;
+import org.bukkit.event.inventory.*;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerItemConsumeEvent;
 import org.bukkit.event.player.PlayerMoveEvent;
 import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
 
 import java.util.Objects;
 
@@ -167,8 +171,81 @@ public class PlayerInteractListener implements Listener
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void OnPlayerConsume(PlayerItemConsumeEvent event)
     {
-        if (!Config.EnableWorlds.contains(event.getPlayer().getWorld().getName())) return;
-        if(event.getItem().isSimilar(OxygenTank.GetItem()))
+        if(event.getItem().isSimilar(OxygenTankProembryo.GetItem())) event.setCancelled(true);
+        if (!Config.EnableWorlds.contains(event.getPlayer().getWorld().getName())){
+            if(event.getItem().isSimilar(OxygenTank.GetItem())) event.setCancelled(true);
+        }
+        if(event.getItem().isSimilar(OxygenTank.GetItem())) {
             OxygenCalculator.ConsumeOxygenTank(event.getPlayer());
+            event.setReplacement(OxygenTankProembryo.GetItem());
+        }
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void OnPlaceBlock(BlockPlaceEvent event)
+    {
+        ItemStack item = event.getItemInHand().clone();
+        if(item.isSimilar(MaskUpgradeT1.GetItem()) || item.isSimilar(MaskUpgradeT2.GetItem()) || item.isSimilar(MaskUpgradeT3.GetItem()))
+        {
+            System.out.println(item.getAmount());
+            System.out.println(MaskUpgradeT1.GetItem().getAmount());
+            Util.Message(event.getPlayer(), MessageManager.msg.CantPlace);
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void OnCraftItem(CraftItemEvent event)
+    {
+        Inventory inv = event.getInventory();
+        for (ItemStack item : inv)
+        {
+            if(item != null && !item.isSimilar(event.getInventory().getResult())) {
+                if (item.isSimilar(MaskUpgradeT1.GetItem())
+                        || item.isSimilar(MaskUpgradeT2.GetItem())
+                        || item.isSimilar(MaskUpgradeT3.GetItem())
+                        || item.isSimilar(RoomDetector.GetItem())
+                        || item.isSimilar(BootStone.GetItem())
+                ) {
+
+                    Util.Message(event.getWhoClicked(), MessageManager.msg.CantCraft);
+                    event.setCancelled(true);
+                }
+            }
+        }
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void OnBrewDone(BrewEvent event)
+    {
+        Inventory inv = event.getContents();
+        for (ItemStack item : inv)
+        {
+            if(item != null) {
+                if (item.isSimilar(OxygenTank.GetItem()) || item.isSimilar(OxygenTankProembryo.GetItem()))
+                {
+                    event.setCancelled(true);
+                }
+            }
+        }
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onInventoryClick(InventoryClickEvent e) {
+        if(e.getInventory().getType() == InventoryType.ANVIL) {
+            if(e.getCurrentItem() != null) {
+                ItemStack item = e.getCurrentItem();
+                if(item.isSimilar(MaskUpgradeT1.GetItem())
+                        || item.isSimilar(MaskUpgradeT2.GetItem())
+                        || item.isSimilar(MaskUpgradeT3.GetItem())
+                        || item.isSimilar(RoomDetector.GetItem())
+                        || item.isSimilar(BootStone.GetItem())
+                        || item.isSimilar(OxygenTank.GetItem())
+                        || item.isSimilar(OxygenTankProembryo.GetItem())
+                        || item.isSimilar(OxygenGenerator.GetItem())
+                        || item.isSimilar(OxygenStation.GetItem()))
+                    e.setCancelled(true);
+            }
+        }
     }
 }

--- a/src/main/java/cn/goldenpotato/oxygensystem/Listener/PlayerInteractListener.java
+++ b/src/main/java/cn/goldenpotato/oxygensystem/Listener/PlayerInteractListener.java
@@ -9,11 +9,15 @@ import cn.goldenpotato.oxygensystem.OxygenSystem;
 import cn.goldenpotato.oxygensystem.Util.OxygenUtil;
 import cn.goldenpotato.oxygensystem.Util.Util;
 import org.bukkit.Sound;
+import org.bukkit.entity.Arrow;
+import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.block.BlockPlaceEvent;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.event.entity.EntityShootBowEvent;
 import org.bukkit.event.inventory.*;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerItemConsumeEvent;
@@ -166,6 +170,9 @@ public class PlayerInteractListener implements Listener
             if(Config.PlayEnterRoomSound)
                 Util.PlaySound(event.getPlayer(), Sound.BLOCK_REDSTONE_TORCH_BURNOUT);
         }
+        if(event.getPlayer().isSprinting()) {
+            OxygenCalculator.SetOxygen(event.getPlayer(), -(float) Config.OxygenReducedOnRunning / 20);
+        }
     }
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
@@ -246,6 +253,20 @@ public class PlayerInteractListener implements Listener
                         || item.isSimilar(OxygenStation.GetItem()))
                     e.setCancelled(true);
             }
+        }
+    }
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void OnPlayerDamaged(EntityDamageByEntityEvent event) {
+        if(event.getDamager() instanceof Player) {
+            Player player = (Player) event.getDamager();
+            OxygenCalculator.SetOxygen(player, -(float) Config.OxygenReducedOnDamagedOthers / 20);
+        }
+    }
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void OnPlayerShootArrow(EntityShootBowEvent event) {
+        if(event.getEntity() instanceof Player) {
+            Player player = (Player) event.getEntity();
+            OxygenCalculator.SetOxygen(player, -(float) Config.OxygenReducedOnDamagedOthers / 20);
         }
     }
 }

--- a/src/main/java/cn/goldenpotato/oxygensystem/Listener/PlayerInteractListener.java
+++ b/src/main/java/cn/goldenpotato/oxygensystem/Listener/PlayerInteractListener.java
@@ -175,7 +175,7 @@ public class PlayerInteractListener implements Listener
         }
     }
 
-    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
     public void OnPlayerConsume(PlayerItemConsumeEvent event)
     {
         if(event.getItem().isSimilar(OxygenTankProembryo.GetItem())) event.setCancelled(true);
@@ -188,20 +188,18 @@ public class PlayerInteractListener implements Listener
         }
     }
 
-    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
     public void OnPlaceBlock(BlockPlaceEvent event)
     {
         ItemStack item = event.getItemInHand().clone();
         if(item.isSimilar(MaskUpgradeT1.GetItem()) || item.isSimilar(MaskUpgradeT2.GetItem()) || item.isSimilar(MaskUpgradeT3.GetItem()))
         {
-            System.out.println(item.getAmount());
-            System.out.println(MaskUpgradeT1.GetItem().getAmount());
             Util.Message(event.getPlayer(), MessageManager.msg.CantPlace);
             event.setCancelled(true);
         }
     }
 
-    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
     public void OnCraftItem(CraftItemEvent event)
     {
         Inventory inv = event.getInventory();
@@ -222,7 +220,7 @@ public class PlayerInteractListener implements Listener
         }
     }
 
-    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
     public void OnBrewDone(BrewEvent event)
     {
         Inventory inv = event.getContents();
@@ -237,7 +235,7 @@ public class PlayerInteractListener implements Listener
         }
     }
 
-    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
     public void onInventoryClick(InventoryClickEvent e) {
         if(e.getInventory().getType() == InventoryType.ANVIL) {
             if(e.getCurrentItem() != null) {
@@ -259,14 +257,14 @@ public class PlayerInteractListener implements Listener
     public void OnPlayerDamaged(EntityDamageByEntityEvent event) {
         if(event.getDamager() instanceof Player) {
             Player player = (Player) event.getDamager();
-            OxygenCalculator.SetOxygen(player, -(float) Config.OxygenReducedOnDamagedOthers / 20);
+            OxygenCalculator.SetOxygen(player, -(float) Config.OxygenReducedOnDamagedOthers);
         }
     }
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void OnPlayerShootArrow(EntityShootBowEvent event) {
         if(event.getEntity() instanceof Player) {
             Player player = (Player) event.getEntity();
-            OxygenCalculator.SetOxygen(player, -(float) Config.OxygenReducedOnDamagedOthers / 20);
+            OxygenCalculator.SetOxygen(player, -(float) Config.OxygenReducedOnDamagedOthers);
         }
     }
 }

--- a/src/main/java/cn/goldenpotato/oxygensystem/Listener/TickListener.java
+++ b/src/main/java/cn/goldenpotato/oxygensystem/Listener/TickListener.java
@@ -24,10 +24,8 @@ public class TickListener implements Listener
         {
             if(!Config.EnableWorlds.contains(player.getWorld().getName())) continue;
             if(player.getGameMode()!= GameMode.SURVIVAL) continue;
-
             if(!OxygenSystem.playerOxygen.containsKey(player.getUniqueId()))
-                OxygenSystem.playerOxygen.put(player.getUniqueId(), OxygenCalculator.GetMaxOxygen(player));
-
+                OxygenSystem.playerOxygen.put(player.getUniqueId(), (double) OxygenCalculator.GetMaxOxygen(player));
             if(SealedRoomCalculator.GetBelong(player.getLocation())==0)
             {
                 boolean result = OxygenCalculator.SetOxygen(player, -1);

--- a/src/main/java/cn/goldenpotato/oxygensystem/Listener/TickListener.java
+++ b/src/main/java/cn/goldenpotato/oxygensystem/Listener/TickListener.java
@@ -1,6 +1,7 @@
 package cn.goldenpotato.oxygensystem.Listener;
 
 import cn.goldenpotato.oxygensystem.Config.Config;
+import cn.goldenpotato.oxygensystem.Item.OxygenTankProembryo;
 import cn.goldenpotato.oxygensystem.Oxygen.OxygenCalculator;
 import cn.goldenpotato.oxygensystem.Oxygen.SealedRoomCalculator;
 import cn.goldenpotato.oxygensystem.OxygenSystem;
@@ -39,6 +40,7 @@ public class TickListener implements Listener
                     {
                         oxygenTank.add(-1);
                         OxygenCalculator.ConsumeOxygenTank(player);
+                        player.getInventory().addItem(OxygenTankProembryo.GetItem());
                     }
                 }
             }

--- a/src/main/java/cn/goldenpotato/oxygensystem/Oxygen/OxygenCalculator.java
+++ b/src/main/java/cn/goldenpotato/oxygensystem/Oxygen/OxygenCalculator.java
@@ -77,7 +77,8 @@ public class OxygenCalculator
 
     public static boolean SetOxygen(Player player, int delta)
     {
-        int oxygen = OxygenSystem.playerOxygen.get(player.getUniqueId());
+        int oxygen = 0;
+        if (OxygenSystem.playerOxygen != null) oxygen = OxygenSystem.playerOxygen.get(player.getUniqueId());
         oxygen += delta;
         oxygen = Math.max(oxygen, 0);
         oxygen = Math.min(oxygen, GetMaxOxygen(player));

--- a/src/main/java/cn/goldenpotato/oxygensystem/Oxygen/OxygenCalculator.java
+++ b/src/main/java/cn/goldenpotato/oxygensystem/Oxygen/OxygenCalculator.java
@@ -75,10 +75,10 @@ public class OxygenCalculator
         return Config.OxygenMask.get(Math.min(Config.OxygenMask.size()-1,GetMaskTier(player)));
     }
 
-    public static boolean SetOxygen(Player player, int delta)
+    public static boolean SetOxygen(Player player, double delta)
     {
-        int oxygen = 0;
-        if (OxygenSystem.playerOxygen != null) oxygen = OxygenSystem.playerOxygen.get(player.getUniqueId());
+        double oxygen = 0;
+        if (OxygenSystem.playerOxygen != null) try{oxygen = OxygenSystem.playerOxygen.get(player.getUniqueId());} catch (NullPointerException ignored){}
         oxygen += delta;
         oxygen = Math.max(oxygen, 0);
         oxygen = Math.min(oxygen, GetMaxOxygen(player));

--- a/src/main/java/cn/goldenpotato/oxygensystem/OxygenSystem.java
+++ b/src/main/java/cn/goldenpotato/oxygensystem/OxygenSystem.java
@@ -21,8 +21,7 @@ public final class OxygenSystem extends JavaPlugin
 {
     public static OxygenSystem instance;
     public static SealedRoomCalculator roomCalculator;
-    public static Map<UUID,Integer> playerOxygen;
-
+    public static Map<UUID,Double> playerOxygen;
     @Override
     public void onEnable()
     {

--- a/src/main/java/cn/goldenpotato/oxygensystem/Util/OxygenUtil.java
+++ b/src/main/java/cn/goldenpotato/oxygensystem/Util/OxygenUtil.java
@@ -15,7 +15,7 @@ public class OxygenUtil
 {
     public static void ShowOxygen(Player player)
     {
-        float per = (float) OxygenSystem.playerOxygen.get(player.getUniqueId()) / OxygenCalculator.GetMaxOxygen(player);
+        float per = (float) (OxygenSystem.playerOxygen.get(player.getUniqueId()) / OxygenCalculator.GetMaxOxygen(player));
         int cnt = Math.round(per * 20);
         if(SealedRoomCalculator.GetBelong(player.getLocation())!=0 && cnt==20)
             return;

--- a/src/main/java/cn/goldenpotato/oxygensystem/Util/Util.java
+++ b/src/main/java/cn/goldenpotato/oxygensystem/Util/Util.java
@@ -80,4 +80,5 @@ public class Util
     {
         return s.replace("[" + key + "]", value);
     }
+
 }

--- a/src/main/java/cn/goldenpotato/oxygensystem/Util/Util.java
+++ b/src/main/java/cn/goldenpotato/oxygensystem/Util/Util.java
@@ -80,5 +80,4 @@ public class Util
     {
         return s.replace("[" + key + "]", value);
     }
-
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -14,6 +14,10 @@ OxygenTank: 300
 RoomOxygenAdd: 5
 #The amount of oxygen recovered by a click of an oxygen station, unit: second
 OxygenStationOxygenAdd: 60
+#实在不会写，对其他实体造成伤害时减少的氧气量
+OxygenReducedOnDamagedOthers: 0.5
+#The amount of oxygen when player running,unit: second/s
+OxygenReducedOnRunning: 0.2
 
 #Sound
 #Whether to play the machine startup sound

--- a/src/main/resources/message_en-US.yml
+++ b/src/main/resources/message_en-US.yml
@@ -13,6 +13,8 @@ LeavingRoom: "§c§lLeaving hermetic cabin"
 AlreadySealed: "§cThis machine is already running."
 NotEnabled: "§cThis machine is not running. Use start stone to enable it"
 OxygenStation_NotInRoom: "§cIt is not in any hermetic cabin or oxygen generator is not enabled."
+CantPlace: "§cYou cant place this block"
+CantCraft: "§cYou cannot craft items using plugin items"
 
 OxygenMaskLore: "§eWith oxygen mask:§c§lT"
 MaskUpgrade_WrongTier: "§cThe currently equipped oxygen system level does not match this upgrader"

--- a/src/main/resources/message_zh-CN.yml
+++ b/src/main/resources/message_zh-CN.yml
@@ -13,6 +13,8 @@ LeavingRoom: "§c§l已离开气密室，请注意氧气消耗"
 AlreadySealed: "§c该机器已在运作"
 NotEnabled: "§c该机器尚未启动，使用启动石来启动它"
 OxygenStation_NotInRoom: "§c该机器未在气密室中，或气密室中氧气生成器尚未启动"
+CantPlace: "§c你不能放置这个方块"
+CantCraft: "§c你不能使用插件物品合成物品"
 
 OxygenMaskLore: "§e已安装氧气系统:§c§lT"
 MaskUpgrade_WrongTier: "§c当前装备的氧气系统等级与该升级器不匹配"


### PR DESCRIPTION
添加了一些事件监听: 
- 阻止玩家使用插件物品合成
- 阻止玩家把升级器放地上
- 阻止玩家重命名插件物品
- 阻止玩家用氧气罐酿造药水