### PR TITLE
Added a new recipe system for 1.21 recipe changes

### DIFF
--- a/src/main/java/cn/goldenpotato/oxygensystem/Item/BootStone.java
+++ b/src/main/java/cn/goldenpotato/oxygensystem/Item/BootStone.java
@@ -9,6 +9,9 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.ShapedRecipe;
 import org.bukkit.inventory.meta.ItemMeta;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class BootStone
 {
     static ItemStack item;
@@ -34,12 +37,24 @@ public class BootStone
         Init();
         NamespacedKey key = new NamespacedKey(OxygenSystem.instance, "boot_stone");
         ShapedRecipe recipe = new ShapedRecipe(key, item);
-        recipe.shape("ABC", "DEF", "GHI");
+        List<Character> shape = new ArrayList<>();
         for(int i=0;i<9;i++)
         {
             Material material = Material.matchMaterial(Config.BootStoneIngredient.get(i));
             if(material==null) material = Material.AIR;
-            recipe.setIngredient((char)('A'+i), material);
+            if (material == Material.AIR) shape.add(' ');
+            else shape.add((char)('A'+i));
+        }
+        recipe.shape("" + shape.get(0) + shape.get(1) + shape.get(2),
+            "" + shape.get(3) + shape.get(4) + shape.get(5),
+            "" + shape.get(6) + shape.get(7) + shape.get(8));
+
+        for(int i=0;i<9;i++)
+        {
+            if (shape.get(i) == ' ') continue;
+            Material material = Material.matchMaterial(Config.BootStoneIngredient.get(i));
+            if(material==null) material = Material.AIR;
+            recipe.setIngredient(shape.get(i), material);
         }
         return recipe;
     }

--- a/src/main/java/cn/goldenpotato/oxygensystem/Item/MaskUpgradeT1.java
+++ b/src/main/java/cn/goldenpotato/oxygensystem/Item/MaskUpgradeT1.java
@@ -9,6 +9,9 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.ShapedRecipe;
 import org.bukkit.inventory.meta.ItemMeta;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class MaskUpgradeT1
 {
     static ItemStack item;
@@ -34,12 +37,24 @@ public class MaskUpgradeT1
         Init();
         NamespacedKey key = new NamespacedKey(OxygenSystem.instance, "mask-upgrade-t1");
         ShapedRecipe recipe = new ShapedRecipe(key, item);
-        recipe.shape("ABC", "DEF", "GHI");
+        List<Character> shape = new ArrayList<>();
         for(int i=0;i<9;i++)
         {
             Material material = Material.matchMaterial(Config.OxygenMaskT1Ingredient.get(i));
             if(material==null) material = Material.AIR;
-            recipe.setIngredient((char)('A'+i), material);
+            if (material == Material.AIR) shape.add(' ');
+            else shape.add((char)('A'+i));
+        }
+        recipe.shape("" + shape.get(0) + shape.get(1) + shape.get(2),
+            "" + shape.get(3) + shape.get(4) + shape.get(5),
+            "" + shape.get(6) + shape.get(7) + shape.get(8));
+
+        for(int i=0;i<9;i++)
+        {
+            if (shape.get(i) == ' ') continue;
+            Material material = Material.matchMaterial(Config.OxygenMaskT1Ingredient.get(i));
+            if(material==null) material = Material.AIR;
+            recipe.setIngredient(shape.get(i), material);
         }
         return recipe;
     }

--- a/src/main/java/cn/goldenpotato/oxygensystem/Item/MaskUpgradeT2.java
+++ b/src/main/java/cn/goldenpotato/oxygensystem/Item/MaskUpgradeT2.java
@@ -9,6 +9,9 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.ShapedRecipe;
 import org.bukkit.inventory.meta.ItemMeta;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class MaskUpgradeT2
 {
     static ItemStack item;
@@ -34,12 +37,24 @@ public class MaskUpgradeT2
         Init();
         NamespacedKey key = new NamespacedKey(OxygenSystem.instance, "mask-upgrade-t2");
         ShapedRecipe recipe = new ShapedRecipe(key, item);
-        recipe.shape("ABC", "DEF", "GHI");
+        List<Character> shape = new ArrayList<>();
         for(int i=0;i<9;i++)
         {
             Material material = Material.matchMaterial(Config.OxygenMaskT2Ingredient.get(i));
             if(material==null) material = Material.AIR;
-            recipe.setIngredient((char)('A'+i), material);
+            if (material == Material.AIR) shape.add(' ');
+            else shape.add((char)('A'+i));
+        }
+        recipe.shape("" + shape.get(0) + shape.get(1) + shape.get(2),
+            "" + shape.get(3) + shape.get(4) + shape.get(5),
+            "" + shape.get(6) + shape.get(7) + shape.get(8));
+
+        for(int i=0;i<9;i++)
+        {
+            if (shape.get(i) == ' ') continue;
+            Material material = Material.matchMaterial(Config.OxygenMaskT2Ingredient.get(i));
+            if(material==null) material = Material.AIR;
+            recipe.setIngredient(shape.get(i), material);
         }
         return recipe;
     }

--- a/src/main/java/cn/goldenpotato/oxygensystem/Item/MaskUpgradeT3.java
+++ b/src/main/java/cn/goldenpotato/oxygensystem/Item/MaskUpgradeT3.java
@@ -9,6 +9,9 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.ShapedRecipe;
 import org.bukkit.inventory.meta.ItemMeta;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class MaskUpgradeT3
 {
     static ItemStack item;
@@ -34,12 +37,24 @@ public class MaskUpgradeT3
         Init();
         NamespacedKey key = new NamespacedKey(OxygenSystem.instance, "mask-upgrade-t3");
         ShapedRecipe recipe = new ShapedRecipe(key, item);
-        recipe.shape("ABC", "DEF", "GHI");
+        List<Character> shape = new ArrayList<>();
         for(int i=0;i<9;i++)
         {
             Material material = Material.matchMaterial(Config.OxygenMaskT3Ingredient.get(i));
             if(material==null) material = Material.AIR;
-            recipe.setIngredient((char)('A'+i), material);
+            if (material == Material.AIR) shape.add(' ');
+            else shape.add((char)('A'+i));
+        }
+        recipe.shape("" + shape.get(0) + shape.get(1) + shape.get(2),
+            "" + shape.get(3) + shape.get(4) + shape.get(5),
+            "" + shape.get(6) + shape.get(7) + shape.get(8));
+
+        for(int i=0;i<9;i++)
+        {
+            if (shape.get(i) == ' ') continue;
+            Material material = Material.matchMaterial(Config.OxygenMaskT3Ingredient.get(i));
+            if(material==null) material = Material.AIR;
+            recipe.setIngredient(shape.get(i), material);
         }
         return recipe;
     }

--- a/src/main/java/cn/goldenpotato/oxygensystem/Item/OxygenGenerator.java
+++ b/src/main/java/cn/goldenpotato/oxygensystem/Item/OxygenGenerator.java
@@ -9,6 +9,9 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.ShapedRecipe;
 import org.bukkit.inventory.meta.ItemMeta;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class OxygenGenerator
 {
     static ItemStack item;
@@ -35,12 +38,24 @@ public class OxygenGenerator
         Init();
         NamespacedKey key = new NamespacedKey(OxygenSystem.instance, "oxygen_generator");
         ShapedRecipe recipe = new ShapedRecipe(key, item);
-        recipe.shape("ABC", "DEF", "GHI");
+        List<Character> shape = new ArrayList<>();
         for(int i=0;i<9;i++)
         {
             Material material = Material.matchMaterial(Config.OxygenGeneratorIngredient.get(i));
             if(material==null) material = Material.AIR;
-            recipe.setIngredient((char)('A'+i), material);
+            if (material == Material.AIR) shape.add(' ');
+            else shape.add((char)('A'+i));
+        }
+        recipe.shape("" + shape.get(0) + shape.get(1) + shape.get(2),
+            "" + shape.get(3) + shape.get(4) + shape.get(5),
+            "" + shape.get(6) + shape.get(7) + shape.get(8));
+
+        for(int i=0;i<9;i++)
+        {
+            if (shape.get(i) == ' ') continue;
+            Material material = Material.matchMaterial(Config.OxygenGeneratorIngredient.get(i));
+            if(material==null) material = Material.AIR;
+            recipe.setIngredient(shape.get(i), material);
         }
         return recipe;
     }

--- a/src/main/java/cn/goldenpotato/oxygensystem/Item/OxygenStation.java
+++ b/src/main/java/cn/goldenpotato/oxygensystem/Item/OxygenStation.java
@@ -9,6 +9,9 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.ShapedRecipe;
 import org.bukkit.inventory.meta.ItemMeta;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class OxygenStation
 {
     static ItemStack item;
@@ -35,12 +38,24 @@ public class OxygenStation
         Init();
         NamespacedKey key = new NamespacedKey(OxygenSystem.instance, "oxygen_station");
         ShapedRecipe recipe = new ShapedRecipe(key, item);
-        recipe.shape("ABC", "DEF", "GHI");
+        List<Character> shape = new ArrayList<>();
         for(int i=0;i<9;i++)
         {
             Material material = Material.matchMaterial(Config.OxygenStationIngredient.get(i));
             if(material==null) material = Material.AIR;
-            recipe.setIngredient((char)('A'+i), material);
+            if (material == Material.AIR) shape.add(' ');
+            else shape.add((char)('A'+i));
+        }
+        recipe.shape("" + shape.get(0) + shape.get(1) + shape.get(2),
+            "" + shape.get(3) + shape.get(4) + shape.get(5),
+            "" + shape.get(6) + shape.get(7) + shape.get(8));
+
+        for(int i=0;i<9;i++)
+        {
+            if (shape.get(i) == ' ') continue;
+            Material material = Material.matchMaterial(Config.OxygenStationIngredient.get(i));
+            if(material==null) material = Material.AIR;
+            recipe.setIngredient(shape.get(i), material);
         }
         return recipe;
     }

--- a/src/main/java/cn/goldenpotato/oxygensystem/Item/OxygenTankProembryo.java
+++ b/src/main/java/cn/goldenpotato/oxygensystem/Item/OxygenTankProembryo.java
@@ -9,6 +9,9 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.ShapedRecipe;
 import org.bukkit.inventory.meta.ItemMeta;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class OxygenTankProembryo
 {
     static ItemStack item;
@@ -34,12 +37,24 @@ public class OxygenTankProembryo
         Init();
         NamespacedKey key = new NamespacedKey(OxygenSystem.instance, "oxygen-tank-proembryo");
         ShapedRecipe recipe = new ShapedRecipe(key, item);
-        recipe.shape("ABC", "DEF", "GHI");
+        List<Character> shape = new ArrayList<>();
         for(int i=0;i<9;i++)
         {
             Material material = Material.matchMaterial(Config.OxygenTankProembryoIngredient.get(i));
             if(material==null) material = Material.AIR;
-            recipe.setIngredient((char)('A'+i), material);
+            if (material == Material.AIR) shape.add(' ');
+            else shape.add((char)('A'+i));
+        }
+        recipe.shape("" + shape.get(0) + shape.get(1) + shape.get(2),
+            "" + shape.get(3) + shape.get(4) + shape.get(5),
+            "" + shape.get(6) + shape.get(7) + shape.get(8));
+
+        for(int i=0;i<9;i++)
+        {
+            if (shape.get(i) == ' ') continue;
+            Material material = Material.matchMaterial(Config.OxygenTankProembryoIngredient.get(i));
+            if(material==null) material = Material.AIR;
+            recipe.setIngredient(shape.get(i), material);
         }
         return recipe;
     }


### PR DESCRIPTION
I saw that on 1.21 the recipes changed and now you cannot put Material.AIR as a recipe slot anymore, it will throw this error if you do that
`java.lang.IllegalArgumentException: Cannot have empty/air choice
	at com.google.common.base.Preconditions.checkArgument(Preconditions.java:143) ~[guava-32.1.2-jre.jar:?]
	at org.bukkit.inventory.RecipeChoice$MaterialChoice.<init>(RecipeChoice.java:100) ~[paper-mojangapi-1.21-R0.1-SNAPSHOT.jar:?]
	at org.bukkit.inventory.ShapedRecipe.setIngredient(ShapedRecipe.java:150) ~[paper-mojangapi-1.21-R0.1-SNAPSHOT.jar:?]
	at org.bukkit.inventory.ShapedRecipe.setIngredient(ShapedRecipe.java:124) ~[paper-mojangapi-1.21-R0.1-SNAPSHOT.jar:?]
	at OxygenSystem 1.2.1.jar/cn.goldenpotato.oxygensystem.Item.MaskUpgradeT2.GetRecipe(MaskUpgradeT2.java:42) ~[OxygenSystem 1.2.1.jar:?]
	at OxygenSystem 1.2.1.jar/cn.goldenpotato.oxygensystem.OxygenSystem.AddRecipe(OxygenSystem.java:57) ~[OxygenSystem 1.2.1.jar:?]
	at OxygenSystem 1.2.1.jar/cn.goldenpotato.oxygensystem.OxygenSystem.onEnable(OxygenSystem.java:44) ~[OxygenSystem 1.2.1.jar:?]`
To fix it, you just need to put an space(' ' char) at the shape for exemple, old way of shape "ABC", and 'A' is Air, you just replace 'A' with a space, new shape " BC", 
**I only tested this on 1.21 and only that ! To be tested on 1.21 below**